### PR TITLE
Add 'locationPersonId' to chayns site data storage and usage

### DIFF
--- a/src/pages/content/components/ChaynsDataReader/app.tsx
+++ b/src/pages/content/components/ChaynsDataReader/app.tsx
@@ -55,6 +55,7 @@ export default function App() {
           domain: chaynsData.site.domain,
           firstName: chaynsData.user?.firstName,
           isAuthorized: chaynsData.user != null,
+          locationPersonId: chaynsData.site.locationPersonId,
           lastName: chaynsData.user?.lastName,
           locationId: chaynsData.site.locationId,
           pageId: getCurrentPageId(),

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -41,6 +41,7 @@ const Popup = () => {
             <CopyableDataRow label={'LocationId'} value={data.locationId} />
             <CopyableDataRow label={'SiteId'} value={data.siteId} />
             <CopyableDataRow label={'PageId'} value={data.pageId} />
+            <CopyableDataRow label={'LocationPersonId'} value={data.locationPersonId} />
             <CopyableDataRow label={'Domain'} value={data.domain} />
           </Table.Tbody>
         </Table>

--- a/src/shared/hooks/useChaynsSiteDataStorage.ts
+++ b/src/shared/hooks/useChaynsSiteDataStorage.ts
@@ -22,6 +22,7 @@ export type Chayns = {
   siteId: string;
   pageId: number;
   locationId: number;
+  locationPersonId: string;
   domain: string;
 };
 


### PR DESCRIPTION
A new field 'locationPersonId' has been added to the chayns site data in 'useChaynsSiteDataStorage.ts'. This field is also now used in 'ChaynsDataReader' and 'Popup' components. This change allows better identification or tracking of location person data across the application.